### PR TITLE
Features/toggle widget

### DIFF
--- a/config/hypr/gen-lockbg.py
+++ b/config/hypr/gen-lockbg.py
@@ -2,8 +2,9 @@
 # gen-lockbg.py — Génère un fond sépia avec texture pixel wave
 # Usage: python3 gen-lockbg.py /chemin/output.png
 
-import sys, random, math
-from pathlib import Path
+import math
+import random
+import sys
 
 try:
     from PIL import Image, ImageDraw
@@ -13,14 +14,14 @@ except ImportError:
 
 out = sys.argv[1] if len(sys.argv) > 1 else "/tmp/lockbg.png"
 
-W, H   = 1920, 1080
-CELL   = 7
-GAP    = 1
-STEP   = CELL + GAP
-cols   = W // STEP
-rows   = H // STEP
+W, H = 1920, 1080
+CELL = 7
+GAP = 1
+STEP = CELL + GAP
+cols = W // STEP
+rows = H // STEP
 
-img  = Image.new("RGB", (W, H), (11, 9, 6))
+img = Image.new("RGB", (W, H), (11, 9, 6))
 draw = ImageDraw.Draw(img)
 
 random.seed(42)  # seed fixe pour cohérence visuelle
@@ -34,7 +35,7 @@ for r in range(rows):
         # Luminosité : uniforme 78%..92% avec jitter
         lum = 0.78 + random.random() * 0.14
         # Légère variation selon la distance au centre (pixels centraux légèrement plus clairs)
-        dist = math.sqrt((c - cx)**2 + (r - cy)**2) / math.sqrt(cx**2 + cy**2)
+        dist = math.sqrt((c - cx) ** 2 + (r - cy) ** 2) / math.sqrt(cx**2 + cy**2)
         lum = lum * (1 - dist * 0.08)
 
         rr = min(255, int(lum * 230))

--- a/config/quickshell/settings/Settings.qml
+++ b/config/quickshell/settings/Settings.qml
@@ -50,6 +50,8 @@ QtObject {
 
     // ── COMPANIONS ──────────────────────────────────────────────
 
+    readonly property bool companionsEnabled: true  // Afficher les compagnons
+
     // Distance du bord droit en pixels
     readonly property int companionsMarginRight: s(20)
 

--- a/config/quickshell/shell.qml
+++ b/config/quickshell/shell.qml
@@ -140,7 +140,7 @@ ShellRoot {
 
     // ── COMPANIONS ──
     Variants {
-        model:Quickshell.screens
+        model:Settings.companionsEnabled ? Quickshell.screens : []
         PanelWindow {
             required property var modelData;screen:modelData
             anchors.bottom:true;anchors.right:true;margins.right:Settings.companionsMarginRight


### PR DESCRIPTION
This pull request introduces a new feature flag to control the display of "companions" in the QuickShell UI and makes minor improvements to code style in the lock screen background generator script. The most important changes are grouped below:

**Feature flag for companions:**

* Added a new read-only property `companionsEnabled` in `Settings.qml` to allow toggling display of companions.
* Updated the `shell.qml` logic so that the companions panel is only displayed if `companionsEnabled` is true, by conditionally setting the model for the panel.

**Code style improvements:**

* Reordered imports in `gen-lockbg.py` for consistency and readability.